### PR TITLE
Use SSL to fetch zxing

### DIFF
--- a/parsepdfs.sh
+++ b/parsepdfs.sh
@@ -4,7 +4,7 @@ SCRIPTDIR=$(dirname $0)
 # Download the binaries (if not yet existing)
 VERSION=3.3.1
 for lib in core javase; do
-  [ -e $SCRIPTDIR/zx-$lib.jar ] || wget http://repo1.maven.org/maven2/com/google/zxing/$lib/$VERSION/$lib-$VERSION.jar -O $SCRIPTDIR/zx-$lib.jar
+  [ -e $SCRIPTDIR/zx-$lib.jar ] || wget https://repo1.maven.org/maven2/com/google/zxing/$lib/$VERSION/$lib-$VERSION.jar -O $SCRIPTDIR/zx-$lib.jar
 done
 [ -e $SCRIPTDIR/jcommander.jar ] || wget https://repo1.maven.org/maven2/com/beust/jcommander/1.72/jcommander-1.72.jar -O $SCRIPTDIR/jcommander.jar
 


### PR DESCRIPTION
Maven no longer supports insecure connections, thus the script currently fails.

Fixes #7.